### PR TITLE
Fix requirements typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 lapx>=0.5.2
-pyntcore>=2023.4.3.0
 ultralytics>=8.0.221
+
+--extra-index-url https://wpilib.jfrog.io/artifactory/api/pypi/wpilib-python-release-2024/simple robotpy
+pyntcore>=2023.4.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-ultralytrics>=8.0.221
+lapx>=0.5.2
 pyntcore>=2023.4.3.0
+ultralytics>=8.0.221
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lapx>=0.5.2
 ultralytics>=8.0.221
 
---extra-index-url https://wpilib.jfrog.io/artifactory/api/pypi/wpilib-python-release-2024/simple robotpy
+--extra-index-url https://wpilib.jfrog.io/artifactory/api/pypi/wpilib-python-release-2024/simple
 pyntcore>=2023.4.3.0
 


### PR DESCRIPTION
Add lapx to the requirements.txt so that gets automatically installed.
Ultralytics was typoed, fixed that.
Made pyntcore work on the coprocessor automatically (hopefully).